### PR TITLE
Add Dagger Hilt Dependency Injection and Navigation Setup

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="GradleMigrationSettings" migrationVersion="1" />
   <component name="GradleSettings">
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>

--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="KotlinJpsPluginSettings">
-    <option name="version" value="2.0.0" />
+    <option name="version" value="2.0.21" />
   </component>
 </project>

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -2,6 +2,8 @@ plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.compose)
+    alias(libs.plugins.hilt.android)
+    alias(libs.plugins.ksp.android)
 }
 
 android {
@@ -56,6 +58,16 @@ dependencies {
     androidTestImplementation(libs.androidx.ui.test.junit4)
     debugImplementation(libs.androidx.ui.tooling)
     debugImplementation(libs.androidx.ui.test.manifest)
+
+    // Hilt
+    implementation(libs.hilt.android)
+    ksp(libs.hilt.compiler)
+    implementation(libs.androidx.hilt.navigation.compose)
+
+    implementation(libs.androidx.navigation.compose)
+
+    // DataStore
+    implementation(libs.androidx.datastore.preferences)
 
     implementation(project(":data"))
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <application
+        android:name=".PingPalsApplication"
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"
@@ -15,7 +16,6 @@
         <activity
             android:name=".MainActivity"
             android:exported="true"
-            android:label="@string/app_name"
             android:theme="@style/Theme.PingPals">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/app/src/main/java/com/example/pingpals/MainActivity.kt
+++ b/app/src/main/java/com/example/pingpals/MainActivity.kt
@@ -3,83 +3,57 @@ package com.example.pingpals
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
-import androidx.compose.animation.animateColorAsState
-import androidx.compose.animation.core.tween
-import androidx.compose.foundation.Image
-import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
+import androidx.activity.viewModels
+import androidx.compose.animation.ExperimentalAnimationApi
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Text
+import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.dp
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.rememberNavController
+import com.example.pingpals.ui.flow.intro.IntroScreen
+import com.example.pingpals.ui.navigation.AppDestinations
+import com.example.pingpals.ui.navigation.AppNavigator
+import com.example.pingpals.ui.navigation.slideComposable
 import com.example.pingpals.ui.theme.PingPalsTheme
+import dagger.hilt.android.AndroidEntryPoint
 
+@AndroidEntryPoint
 class MainActivity : ComponentActivity() {
+
+    private val viewModel: MainViewModel by viewModels()
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContent {
             PingPalsTheme {
-                Scaffold(modifier = Modifier.fillMaxSize()) { innerPadding ->
-                    WelcomeScreen(modifier = Modifier.padding(innerPadding))
+                Surface(
+                    modifier = Modifier.fillMaxSize(),
+                    color = MaterialTheme.colorScheme.background
+                ) {
+                    MainApp(viewModel)
                 }
             }
         }
     }
 }
 
+@OptIn(ExperimentalAnimationApi::class)
 @Composable
-fun WelcomeScreen(modifier: Modifier = Modifier) {
-    val backgroundColor by animateColorAsState(
-        targetValue = Color(0xFF87B5F5),
-        animationSpec = tween(durationMillis = 2000)
-    )
+fun MainApp(viewModel: MainViewModel) {
+    val navController = rememberNavController()
+    val state by viewModel.state.collectAsState()
 
-    Box(
-        modifier = modifier
-            .fillMaxSize()
-            .background(backgroundColor),
-        contentAlignment = Alignment.Center
-    ) {
-        Column(horizontalAlignment = Alignment.CenterHorizontally) {
-            Image(
-                painter = painterResource(id = R.drawable.ic_app_logo),
-                contentDescription = "PingPals Logo",
-                modifier = Modifier
-                    .size(120.dp)
-                    .padding(bottom = 16.dp)
-            )
-            Text(
-                text = "Welcome to PingPals!",
-                style = MaterialTheme.typography.headlineMedium,
-                color = Color.Black
-            )
-            Spacer(modifier = Modifier.height(16.dp))
-            Text(
-                text = "Instant Connections, Seamlessly Simplified!",
-                style = MaterialTheme.typography.bodyLarge,
-                color = Color.Black
-            )
+    AppNavigator(navController = navController, viewModel.navActions)
+
+    state.initialRoute?.let {
+        NavHost(navController = navController, startDestination = state.initialRoute!!) {
+            slideComposable(AppDestinations.intro.path) {
+                IntroScreen()
+            }
         }
-    }
-}
-
-@Preview(showBackground = true)
-@Composable
-fun WelcomeScreenPreview() {
-    PingPalsTheme {
-        WelcomeScreen()
     }
 }

--- a/app/src/main/java/com/example/pingpals/MainViewModel.kt
+++ b/app/src/main/java/com/example/pingpals/MainViewModel.kt
@@ -1,0 +1,37 @@
+package com.example.pingpals
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.data.storage.UserPreferences
+import com.example.pingpals.ui.navigation.AppDestinations
+import com.example.pingpals.ui.navigation.AppNavigator
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class MainViewModel @Inject constructor(
+    private val navigator: AppNavigator,
+    private val userPreferences: UserPreferences
+) : ViewModel() {
+    val navActions = navigator.navigationChannel
+    private val _state = MutableStateFlow(MainScreenState())
+    val state = _state.asStateFlow()
+
+    init {
+        viewModelScope.launch {
+            val initialRoute = when {
+                !userPreferences.isIntroShown() -> AppDestinations.intro.path
+                else -> null
+            }
+
+            _state.value = state.value.copy(initialRoute = initialRoute)
+        }
+    }
+}
+
+data class MainScreenState(
+    val initialRoute: String? = null,
+)

--- a/app/src/main/java/com/example/pingpals/PingPalsApplication.kt
+++ b/app/src/main/java/com/example/pingpals/PingPalsApplication.kt
@@ -1,0 +1,13 @@
+package com.example.pingpals
+
+import android.app.Application
+import com.example.data.storage.UserPreferences
+import dagger.hilt.android.HiltAndroidApp
+import javax.inject.Inject
+
+@HiltAndroidApp
+class PingPalsApplication : Application(){
+    @Inject
+    lateinit var userPreferences: UserPreferences
+
+}

--- a/app/src/main/java/com/example/pingpals/domain/di/AppDataProvider.kt
+++ b/app/src/main/java/com/example/pingpals/domain/di/AppDataProvider.kt
@@ -1,0 +1,11 @@
+package com.example.pingpals.domain.di
+
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+
+@Module
+@InstallIn(SingletonComponent::class)
+class AppDataProvider {
+
+}

--- a/app/src/main/java/com/example/pingpals/ui/flow/intro/IntroScreen.kt
+++ b/app/src/main/java/com/example/pingpals/ui/flow/intro/IntroScreen.kt
@@ -1,0 +1,60 @@
+package com.example.pingpals.ui.flow.intro
+
+import androidx.compose.animation.animateColorAsState
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.unit.dp
+import com.example.pingpals.R
+
+@Composable
+fun IntroScreen() {
+
+    val backgroundColor by animateColorAsState(
+        targetValue = Color(0xFF87B5F5),
+        animationSpec = tween(durationMillis = 2000)
+    )
+
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(backgroundColor),
+        contentAlignment = Alignment.Center
+    ) {
+        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+            Image(
+                painter = painterResource(id = R.drawable.ic_app_logo),
+                contentDescription = "PingPals Logo",
+                modifier = Modifier
+                    .size(120.dp)
+                    .padding(bottom = 16.dp)
+            )
+            Text(
+                text = "Welcome to PingPals!",
+                style = MaterialTheme.typography.headlineMedium,
+                color = Color.Black
+            )
+            Spacer(modifier = Modifier.height(16.dp))
+            Text(
+                text = "Instant Connections, Seamlessly Simplified!",
+                style = MaterialTheme.typography.bodyLarge,
+                color = Color.Black
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/example/pingpals/ui/flow/intro/IntroViewModel.kt
+++ b/app/src/main/java/com/example/pingpals/ui/flow/intro/IntroViewModel.kt
@@ -1,0 +1,10 @@
+package com.example.pingpals.ui.flow.intro
+
+import androidx.lifecycle.ViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+
+@HiltViewModel
+class IntroViewModel @Inject constructor(): ViewModel() {
+
+}

--- a/app/src/main/java/com/example/pingpals/ui/navigation/AppNavigator.kt
+++ b/app/src/main/java/com/example/pingpals/ui/navigation/AppNavigator.kt
@@ -1,0 +1,110 @@
+package com.example.pingpals.ui.navigation
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.navigation.NavHostController
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.collectLatest
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class AppNavigator @Inject constructor() {
+
+    private val _navigationChannel =
+        MutableSharedFlow<NavAction>(extraBufferCapacity = 1)
+    val navigationChannel = _navigationChannel.asSharedFlow()
+
+    fun navigateBack(
+        route: String? = null,
+        inclusive: Boolean = false,
+        result: Map<String, Any>? = null
+    ) {
+        _navigationChannel.tryEmit(
+            NavAction.NavigateBack(
+                route = route,
+                inclusive = inclusive,
+                result = result
+            )
+        )
+    }
+
+    fun navigateTo(
+        route: String,
+        popUpToRoute: String? = null,
+        inclusive: Boolean = false,
+        clearStack: Boolean = false
+    ) {
+        _navigationChannel.tryEmit(
+            NavAction.NavigateTo(
+                route = route,
+                popUpToRoute = popUpToRoute,
+                inclusive = inclusive,
+                clearStack = clearStack
+            )
+        )
+    }
+}
+
+sealed class NavAction {
+
+    data class NavigateBack(
+        val route: String? = null,
+        val inclusive: Boolean = false,
+        val result: Map<String, Any?>? = null
+    ) : NavAction()
+
+    data class NavigateTo(
+        val route: String,
+        val popUpToRoute: String? = null,
+        val inclusive: Boolean = false,
+        val clearStack: Boolean = false
+    ) : NavAction()
+}
+
+@Composable
+fun AppNavigator(navController: NavHostController, navActions: SharedFlow<NavAction?>) {
+    LaunchedEffect(Unit) {
+        navActions.collectLatest { action ->
+            val navAction = action ?: return@collectLatest
+
+            when (navAction) {
+                is NavAction.NavigateBack -> {
+                    if (navAction.route != null) {
+                        if (navAction.result != null) {
+                            navController.getBackStackEntry(navAction.route).savedStateHandle.also { savedStateHandle ->
+                                navAction.result.forEach { (key, value) ->
+                                    savedStateHandle[key] = value
+                                }
+                            }
+                        }
+                        navController.popBackStack(navAction.route, navAction.inclusive)
+                    } else {
+                        if (navAction.result != null) {
+                            navController.previousBackStackEntry?.savedStateHandle.also { savedStateHandle ->
+                                navAction.result.forEach { (key, value) ->
+                                    savedStateHandle?.set(key, value)
+                                }
+                            }
+                        }
+                        navController.popBackStack()
+                    }
+                }
+
+                is NavAction.NavigateTo -> {
+                    navController.navigate(navAction.route) {
+                        if (navAction.clearStack) {
+                            popUpTo(navController.graph.id) { inclusive = true }
+                        } else {
+                            navAction.popUpToRoute?.let { popUpToRoute ->
+                                popUpTo(popUpToRoute) { inclusive = navAction.inclusive }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/pingpals/ui/navigation/AppRoute.kt
+++ b/app/src/main/java/com/example/pingpals/ui/navigation/AppRoute.kt
@@ -1,0 +1,30 @@
+package com.example.pingpals.ui.navigation
+
+import androidx.navigation.NamedNavArgument
+
+interface AppRoute {
+    val arguments: List<NamedNavArgument>
+    val path: String
+}
+
+object AppDestinations {
+    val intro = object : AppRoute {
+        override val arguments: List<NamedNavArgument> = emptyList()
+        override val path: String = "intro"
+    }
+
+    val login = object : AppRoute {
+        override val arguments: List<NamedNavArgument> = emptyList()
+        override val path: String = "login"
+    }
+
+    val signIn = object : AppRoute {
+        override val arguments: List<NamedNavArgument> = emptyList()
+        override val path: String = "sign-in"
+    }
+
+    val home = object : AppRoute {
+        override val arguments: List<NamedNavArgument> = emptyList()
+        override val path: String = "home"
+    }
+}

--- a/app/src/main/java/com/example/pingpals/ui/navigation/NavAnimation.kt
+++ b/app/src/main/java/com/example/pingpals/ui/navigation/NavAnimation.kt
@@ -1,0 +1,78 @@
+package com.example.pingpals.ui.navigation
+
+import androidx.compose.animation.AnimatedContentScope
+import androidx.compose.animation.AnimatedContentTransitionScope
+import androidx.compose.animation.EnterTransition
+import androidx.compose.animation.ExitTransition
+import androidx.compose.animation.ExperimentalAnimationApi
+import androidx.compose.animation.core.LinearOutSlowInEasing
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.slideInHorizontally
+import androidx.compose.animation.slideOutHorizontally
+import androidx.compose.runtime.Composable
+import androidx.navigation.NamedNavArgument
+import androidx.navigation.NavBackStackEntry
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.compose.composable
+
+@ExperimentalAnimationApi
+fun NavGraphBuilder.slideComposable(
+    route: String,
+    arguments: List<NamedNavArgument> = emptyList(),
+    content: @Composable (AnimatedContentScope.(NavBackStackEntry) -> Unit)
+) {
+    composable(
+        route,
+        arguments = arguments,
+        enterTransition = enterTransition,
+        exitTransition = exitTransition,
+        popEnterTransition = popEnterTransition,
+        popExitTransition = popExitTransition,
+        content = content
+    )
+}
+
+@ExperimentalAnimationApi
+fun NavGraphBuilder.tabComposable(
+    route: String,
+    arguments: List<NamedNavArgument> = emptyList(),
+    content: @Composable (AnimatedContentScope.(NavBackStackEntry) -> Unit)
+) {
+    composable(
+        route,
+        arguments = arguments,
+        popEnterTransition = popEnterTransition,
+        popExitTransition = popExitTransition,
+        content = content
+    )
+}
+
+private const val TIME_DURATION = 300
+
+val enterTransition: AnimatedContentTransitionScope<NavBackStackEntry>.() -> EnterTransition = {
+    slideInHorizontally(
+        initialOffsetX = { it },
+        animationSpec = tween(durationMillis = TIME_DURATION, easing = LinearOutSlowInEasing)
+    )
+}
+
+val exitTransition: AnimatedContentTransitionScope<NavBackStackEntry>.() -> ExitTransition = {
+    slideOutHorizontally(
+        targetOffsetX = { -it / 3 },
+        animationSpec = tween(durationMillis = TIME_DURATION, easing = LinearOutSlowInEasing)
+    )
+}
+
+val popEnterTransition: AnimatedContentTransitionScope<NavBackStackEntry>.() -> EnterTransition = {
+    slideInHorizontally(
+        initialOffsetX = { -it / 3 },
+        animationSpec = tween(durationMillis = TIME_DURATION, easing = LinearOutSlowInEasing)
+    )
+}
+
+val popExitTransition: AnimatedContentTransitionScope<NavBackStackEntry>.() -> ExitTransition = {
+    slideOutHorizontally(
+        targetOffsetX = { it },
+        animationSpec = tween(durationMillis = TIME_DURATION, easing = LinearOutSlowInEasing)
+    )
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,4 +4,6 @@ plugins {
     alias(libs.plugins.kotlin.android) apply false
     alias(libs.plugins.kotlin.compose) apply false
     alias(libs.plugins.android.library) apply false
+    alias(libs.plugins.hilt.android) apply false
+    alias(libs.plugins.ksp.android) apply false
 }

--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -1,6 +1,8 @@
 plugins {
     alias(libs.plugins.android.library)
     alias(libs.plugins.kotlin.android)
+    id("com.google.dagger.hilt.android")
+    id("com.google.devtools.ksp")
 }
 
 android {
@@ -40,4 +42,11 @@ dependencies {
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
+
+    // Hilt
+    implementation(libs.hilt.android)
+    ksp(libs.hilt.compiler)
+
+    // DataStore
+    implementation(libs.androidx.datastore.preferences)
 }

--- a/data/src/main/java/com/example/data/di/AppDataProvider.kt
+++ b/data/src/main/java/com/example/data/di/AppDataProvider.kt
@@ -1,0 +1,11 @@
+package com.example.data.di
+
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+
+@Module
+@InstallIn(SingletonComponent::class)
+class AppDataProvider {
+
+}

--- a/data/src/main/java/com/example/data/storage/PreferencesProvider.kt
+++ b/data/src/main/java/com/example/data/storage/PreferencesProvider.kt
@@ -1,0 +1,29 @@
+package com.example.data.storage
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.preferencesDataStoreFile
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Named
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+class PreferencesProvider {
+
+    @Provides
+    @Singleton
+    @Named(PREF_USER_PREFERENCES)
+    fun provideUserDatastore(@ApplicationContext context: Context): DataStore<Preferences> =
+        PreferenceDataStoreFactory.create(
+            produceFile = {
+                context.preferencesDataStoreFile(PREF_USER_PREFERENCES)
+            }
+        )
+}

--- a/data/src/main/java/com/example/data/storage/UserPreferences.kt
+++ b/data/src/main/java/com/example/data/storage/UserPreferences.kt
@@ -1,0 +1,33 @@
+package com.example.data.storage
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.edit
+import kotlinx.coroutines.flow.first
+import javax.inject.Inject
+import javax.inject.Named
+import javax.inject.Singleton
+
+const val PREF_USER_PREFERENCES = "ping_pals_user_preferences"
+
+@Singleton
+class UserPreferences @Inject constructor(
+    @Named(PREF_USER_PREFERENCES) private val preferencesDataStore: DataStore<Preferences>,
+) {
+
+    object PreferencesKey {
+        val INTRO_SHOWN = booleanPreferencesKey("intro_shown")
+    }
+
+    suspend fun isIntroShown(): Boolean {
+        return preferencesDataStore.data.first()[PreferencesKey.INTRO_SHOWN] ?: false
+    }
+
+    suspend fun setIntroShown(value: Boolean) {
+        preferencesDataStore.edit { preferences ->
+            preferences[PreferencesKey.INTRO_SHOWN] = value
+        }
+    }
+
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,8 @@
 [versions]
 agp = "8.8.0"
-kotlin = "2.0.0"
+datastorePreferences = "1.1.2"
+hiltNavigationCompose = "1.2.0"
+kotlin = "2.0.21"
 coreKtx = "1.15.0"
 junit = "4.13.2"
 junitVersion = "1.2.1"
@@ -10,9 +12,17 @@ activityCompose = "1.10.0"
 composeBom = "2025.01.00"
 appcompat = "1.7.0"
 material = "1.12.0"
+hilt = "2.51.1"
+ksp = "2.0.21-1.0.28"
+navigationCompose = "2.8.5"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
+androidx-datastore-preferences = { module = "androidx.datastore:datastore-preferences", version.ref = "datastorePreferences" }
+androidx-hilt-navigation-compose = { module = "androidx.hilt:hilt-navigation-compose", version.ref = "hiltNavigationCompose" }
+androidx-navigation-compose = { module = "androidx.navigation:navigation-compose", version.ref = "navigationCompose" }
+hilt-android = { module = "com.google.dagger:hilt-android", version.ref = "hilt" }
+hilt-compiler = { module = "com.google.dagger:hilt-compiler", version.ref = "hilt" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }
 androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCore" }
@@ -34,4 +44,7 @@ android-application = { id = "com.android.application", version.ref = "agp" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 android-library = { id = "com.android.library", version.ref = "agp" }
+hilt-android = { id = "com.google.dagger.hilt.android", version.ref = "hilt" }
+ksp-android = {id = "com.google.devtools.ksp", version.ref = "ksp"}
+
 


### PR DESCRIPTION
Dagger Hilt Integration:
Configured Hilt in the project with the @HiltAndroidApp annotation in the Application class.
Added modules to provide dependencies like DataStore, Repository, etc.
Updated ViewModels and other classes to use @Inject for dependency injection.

Navigation Setup:
Integrated NavHost and NavController for managing app navigation.
Defined navigation routes for different screens.
Created a navigation graph to handle transitions between screens.

Gradle Changes:
Added necessary dependencies for Hilt and Navigation in the build.gradle file.
Configured ksp for Hilt annotation processing.
